### PR TITLE
fix: resetAccount should reject the promise with a `notFound` error if the account is not found.

### DIFF
--- a/db.js
+++ b/db.js
@@ -347,20 +347,20 @@ module.exports = function (error) {
     uid = uid.toString('hex')
 
     var account = accounts[uid]
-    if ( account ) {
-      deleteUid(uid, sessionTokens)
-      deleteUid(uid, keyFetchTokens)
-      deleteUid(uid, accountResetTokens)
-      deleteUid(uid, passwordChangeTokens)
-      deleteUid(uid, passwordForgotTokens)
+    if (!account) { return P.reject(error.notFound()) }
 
-      account.verifyHash = data.verifyHash
-      account.authSalt = data.authSalt
-      account.wrapWrapKb = data.wrapWrapKb
-      account.verifierSetAt = Date.now()
-      account.verifierVersion = data.verifierVersion
-      account.devices = {}
-    }
+    deleteUid(uid, sessionTokens)
+    deleteUid(uid, keyFetchTokens)
+    deleteUid(uid, accountResetTokens)
+    deleteUid(uid, passwordChangeTokens)
+    deleteUid(uid, passwordForgotTokens)
+
+    account.verifyHash = data.verifyHash
+    account.authSalt = data.authSalt
+    account.wrapWrapKb = data.wrapWrapKb
+    account.verifierSetAt = Date.now()
+    account.verifierVersion = data.verifierVersion
+    account.devices = {}
 
     return P.resolve({})
   }


### PR DESCRIPTION
Updating the fxa-auth-server to use the fxa-auth-db-mem instead of the Heap DB introduced a subtle change in resetAccount. The Heap DB rejected the promise with an `unknownAccount` error if the account's uid was not found, the fxa-auth-db-mem equivalent does not.

This change checks whether an account exists, if it does not, reject the promise with a `notFound` error.

fixes https://github.com/mozilla/fxa-auth-server/issues/773
Causes all tests referenced in https://github.com/mozilla/fxa-content-server/pull/1455 to pass.
