### PR TITLE
Fix relative import paths in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var config = require('../config')
+var config = require('./config')
 var dbServer = require('fxa-auth-db-server')
 var error = dbServer.errors
-var log = require('../log')(config.logLevel, 'db-api')
-var DB = require('../db')(log, error)
+var log = require('./log')(config.logLevel, 'db-api')
+var DB = require('./db')(log, error)
 
 module.exports = function () {
   return DB.connect(config)


### PR DESCRIPTION
Looks like we forgot to update some `require` paths in the refactor.  This fixes them so they'll work correctly with fxa-auth-server.