### PR TITLE
Use uuid@1.4.x, not uuid@2.x

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "ass": {
       "version": "1.0.0",
-      "from": "ass@git://github.com/jrgm/ass.git#5be99ee",
+      "from": "git://github.com/jrgm/ass.git#5be99ee",
       "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "dependencies": {
         "async": {
@@ -19,22 +19,22 @@
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "falafel@~0.1.6",
+              "from": "falafel@>=0.1.6 <0.2.0",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "xtend@~2.1.1",
+              "from": "xtend@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@~0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -48,32 +48,32 @@
           "dependencies": {
             "htmlparser2": {
               "version": "3.7.3",
-              "from": "htmlparser2@~3.7.0",
+              "from": "htmlparser2@>=3.7.0 <3.8.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "domhandler@2.2",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@1.5",
+                  "from": "domutils@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "domelementtype@~1.1.1",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@~1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -82,17 +82,17 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "domelementtype@1",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -102,12 +102,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -116,27 +116,27 @@
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@1.0",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "CSSselect@~0.4.0",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "CSSwhat@0.4",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "domutils@1.4",
+                  "from": "domutils@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.3.0",
-                      "from": "domelementtype@1",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                     }
                   }
@@ -145,7 +145,7 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
@@ -157,7 +157,7 @@
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@~2.2.6",
+              "from": "rimraf@>=2.2.6 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
@@ -186,32 +186,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -220,7 +220,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -244,12 +244,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -263,8 +263,8 @@
     },
     "fxa-auth-db-server": {
       "version": "0.33.0",
-      "from": "fxa-auth-db-server@git://github.com/mozilla/fxa-auth-db-server.git",
-      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#f1bf9b526f67daf278ce5539c6521f145570a842",
+      "from": "git://github.com/mozilla/fxa-auth-db-server.git",
+      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#b10eac986317ffffd77549d1c1dda103d3f297a2",
       "dependencies": {
         "restify": {
           "version": "2.8.2",
@@ -335,9 +335,9 @@
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                 },
                 "csv-parse": {
-                  "version": "0.0.9",
-                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.0.9.tgz"
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
                 },
                 "stream-transform": {
                   "version": "0.0.7",
@@ -404,9 +404,9 @@
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             },
             "node-uuid": {
-              "version": "1.4.2",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "once": {
               "version": "1.3.1",
@@ -431,9 +431,9 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
-              "version": "1.30.2",
-              "from": "https://registry.npmjs.org/spdy/-/spdy-1.30.2.tgz",
-              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.30.2.tgz"
+              "version": "1.31.0",
+              "from": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz",
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
@@ -458,343 +458,6 @@
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
-        },
-        "bluebird": {
-          "version": "1.2.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.2.tgz"
-        },
-        "uuid": {
-          "version": "1.4.1",
-          "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
-        },
-        "tap": {
-          "version": "0.4.12",
-          "from": "https://registry.npmjs.org/tap/-/tap-0.4.12.tgz",
-          "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.12.tgz",
-          "dependencies": {
-            "buffer-equal": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
-            },
-            "deep-equal": {
-              "version": "0.0.0",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
-            },
-            "difflet": {
-              "version": "0.2.6",
-              "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
-              "dependencies": {
-                "traverse": {
-                  "version": "0.6.6",
-                  "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-                  "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
-                },
-                "charm": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
-                },
-                "deep-is": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@*"
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "nopt": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                }
-              }
-            },
-            "runforcover": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
-              "dependencies": {
-                "bunker": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
-                  "dependencies": {
-                    "burrito": {
-                      "version": "0.2.12",
-                      "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
-                      "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
-                      "dependencies": {
-                        "traverse": {
-                          "version": "0.5.2",
-                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
-                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
-                        },
-                        "uglify-js": {
-                          "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "slide": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-            },
-            "yamlish": {
-              "version": "0.0.5",
-              "from": "yamlish@*"
-            },
-            "tap-consumer": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/tap-consumer/-/tap-consumer-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/tap-consumer/-/tap-consumer-0.0.1.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "tap-results": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/tap-results/-/tap-results-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/tap-results/-/tap-results-0.0.2.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    }
-                  }
-                },
-                "yamlish": {
-                  "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "ass": {
-          "version": "1.0.0",
-          "from": "ass@git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
-          "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
-          "dependencies": {
-            "async": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            },
-            "blanket": {
-              "version": "1.1.6",
-              "from": "blanket@1.1.6",
-              "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                },
-                "falafel": {
-                  "version": "0.1.6",
-                  "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
-                },
-                "xtend": {
-                  "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                  "dependencies": {
-                    "object-keys": {
-                      "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "cheerio": {
-              "version": "0.14.0",
-              "from": "cheerio@0.14.0",
-              "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
-              "dependencies": {
-                "htmlparser2": {
-                  "version": "3.7.3",
-                  "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
-                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
-                  "dependencies": {
-                    "domhandler": {
-                      "version": "2.2.1",
-                      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
-                    },
-                    "domutils": {
-                      "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                      "dependencies": {
-                        "dom-serializer": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                          "dependencies": {
-                            "domelementtype": {
-                              "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                            },
-                            "entities": {
-                              "version": "1.1.1",
-                              "from": "entities@~1.1.1",
-                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "domelementtype": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-                },
-                "CSSselect": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
-                  "dependencies": {
-                    "CSSwhat": {
-                      "version": "0.4.7",
-                      "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
-                      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
-                    },
-                    "domutils": {
-                      "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-                }
-              }
-            },
-            "temp": {
-              "version": "0.8.1",
-              "from": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
-              "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
-              "dependencies": {
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@~2.2.6",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -805,17 +468,17 @@
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -825,37 +488,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -864,144 +527,144 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -1015,37 +678,37 @@
       "dependencies": {
         "jshint": {
           "version": "2.5.11",
-          "from": "jshint@~2.5.0",
+          "from": "jshint@>=2.5.0 <2.6.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
           "dependencies": {
             "cli": {
-              "version": "0.6.5",
-              "from": "cli@0.6.x",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+              "version": "0.6.6",
+              "from": "cli@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@~ 3.2.1",
+                  "from": "glob@>=3.2.1 <3.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@0.3",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -1056,49 +719,49 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@1.1.x",
+              "from": "console-browserify@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@^0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@0.1.x",
+              "from": "exit@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "htmlparser2@3.8.x",
+              "from": "htmlparser2@>=3.8.0 <3.9.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "domhandler@2.3",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@1.5",
+                  "from": "domutils@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "domelementtype@~1.1.1",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@~1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -1107,17 +770,17 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "domelementtype@1",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -1127,60 +790,60 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "entities@1.0",
+                  "from": "entities@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@1.0.x",
+              "from": "minimatch@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@0.3.x",
+              "from": "shelljs@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@1.0.x",
+              "from": "strip-json-comments@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "underscore@1.6.x",
+              "from": "underscore@>=1.6.0 <1.7.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
@@ -1197,27 +860,27 @@
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
+          "from": "cli-color@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@~0.9.2",
+              "from": "es5-ext@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
+              "from": "memoizee@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2",
+                  "from": "event-emitter@>=0.2.2 <0.3.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@0.1.x",
+                  "from": "next-tick@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -1226,27 +889,27 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@^0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "request": {
           "version": "2.54.0",
-          "from": "request@^2.34.0",
+          "from": "request@>=2.34.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.54.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@~0.9.0",
+              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -1256,12 +919,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1270,56 +933,56 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@~0.9.0",
+              "from": "caseless@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.0",
-              "from": "forever-agent@~0.6.0",
+              "from": "forever-agent@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.0.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@~0.2.0",
+              "from": "form-data@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@~0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "2.0.10",
-              "from": "mime-types@~2.0.1",
+              "from": "mime-types@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.8.0",
-                  "from": "mime-db@~1.8.0",
+                  "from": "mime-db@>=1.8.0 <1.9.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@~1.4.0",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
               "version": "2.4.1",
-              "from": "qs@~2.4.0",
+              "from": "qs@>=2.4.0 <2.5.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
@@ -1336,12 +999,12 @@
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@~0.10.0",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -1358,49 +1021,49 @@
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@~0.6.0",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@~2.3.0",
+              "from": "hawk@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.12.0",
-                  "from": "hoek@2.x.x",
+                  "from": "hoek@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
                 },
                 "boom": {
                   "version": "2.6.1",
-                  "from": "boom@2.x.x",
+                  "from": "boom@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@1.x.x",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@~0.0.5",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -1412,137 +1075,115 @@
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@~0.1.1",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
-              "version": "1.4.0",
-              "from": "har-validator@^1.4.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.4.0.tgz",
+              "version": "1.5.1",
+              "from": "har-validator@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.5.1.tgz",
               "dependencies": {
-                "async": {
-                  "version": "0.9.0",
-                  "from": "async@^0.9.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                },
                 "bluebird": {
-                  "version": "2.9.15",
-                  "from": "bluebird@^2.9.14",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz"
+                  "version": "2.9.21",
+                  "from": "bluebird@>=2.9.14 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.21.tgz"
                 },
                 "chalk": {
                   "version": "1.0.0",
-                  "from": "chalk@^1.0.0",
+                  "from": "chalk@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.0.1",
-                      "from": "ansi-styles@^2.0.1",
+                      "from": "ansi-styles@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@^1.0.2",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "1.0.3",
-                      "from": "has-ansi@^1.0.3",
+                      "from": "has-ansi@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@^1.1.0",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         },
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "get-stdin@^4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@^2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@^1.1.0",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "1.3.1",
-                      "from": "supports-color@^1.3.0",
+                      "from": "supports-color@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.7.1",
-                  "from": "commander@^2.7.1",
+                  "from": "commander@>=2.7.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "2.1.3",
-                  "from": "debug@^2.1.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.0",
-                      "from": "ms@0.7.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.10.0",
-                  "from": "is-my-json-valid@^2.10.0",
+                  "from": "is-my-json-valid@>=2.10.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@^2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
-                      "version": "1.1.0",
-                      "from": "generate-object-property@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.0.tgz",
+                      "version": "1.1.1",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@^1.0.0",
+                          "from": "is-property@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "jsonpointer@^1.1.0",
+                      "from": "jsonpointer@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@^4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
-                },
-                "require-directory": {
-                  "version": "2.1.0",
-                  "from": "require-directory@^2.1.0",
-                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.0.tgz"
                 }
               }
             }
@@ -1550,7 +1191,7 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -1562,32 +1203,32 @@
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@^0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -1596,46 +1237,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.3.0",
-          "from": "multimatch@^0.3.0",
+          "from": "multimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "0.1.0",
-              "from": "array-differ@^0.1.0",
+              "from": "array-differ@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
             },
             "array-union": {
               "version": "0.1.0",
-              "from": "array-union@^0.1.0",
+              "from": "array-union@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "0.1.1",
-                  "from": "array-uniq@^0.1.0",
+                  "from": "array-uniq@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@^0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -1651,85 +1292,85 @@
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "intel@^1.0.0",
+          "from": "intel@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@~0.4.2",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@~0.0.9",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.4",
-              "from": "strftime@~0.8.2",
+              "from": "strftime@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@~0.2.0",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@~0.1.0",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@^1.2.0",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
@@ -1741,54 +1382,54 @@
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "buffer-equal@~0.0.0",
+          "from": "buffer-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@~0.0.0",
+          "from": "deep-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "difflet@~0.2.0",
+          "from": "difflet@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "traverse@0.6.x",
+              "from": "traverse@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "charm@0.1.x",
+              "from": "charm@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@0.1.x",
+              "from": "deep-is@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2.9",
+          "from": "glob@>=3.2.9 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@0.3",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -1802,7 +1443,7 @@
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@~0.3 || 0.4 || 0.5",
+          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
@@ -1814,39 +1455,39 @@
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "nopt@~2",
+          "from": "nopt@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "runforcover@~0.0.2",
+          "from": "runforcover@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "bunker@0.1.X",
+              "from": "bunker@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "burrito@>=0.2.5 <0.3",
+                  "from": "burrito@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "traverse@~0.5.1",
+                      "from": "traverse@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "uglify-js@~1.1.1",
+                      "from": "uglify-js@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -1857,7 +1498,7 @@
         },
         "slide": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "from": "slide@*",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "yamlish": {
@@ -1868,9 +1509,9 @@
       }
     },
     "uuid": {
-      "version": "2.0.1",
-      "from": "uuid@^2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+      "version": "1.4.1",
+      "from": "uuid@1.4.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-nsp-shrinkwrap": "0.0.3",
     "load-grunt-tasks": "0.6.0",
     "tap": "0.4.13",
-    "uuid": "^2.0.1"
+    "uuid": "1.4.1"
   },
   "keywords": [ "fxa", "firefox", "firefox-accounts", "backend", "storage", "memory" ]
 }


### PR DESCRIPTION
This addresses somewhat https://github.com/mozilla/fxa-auth-db-mem/issues/23, by using uuid@1.4.1 which returns a Buffer from `uuid.v4('binary')` and is the version used by fxa-auth-db-mysql, et al.

r? @chilts (or if @chilts is still sick @dannycoates)