### PR TITLE
fix(logging): load the logger from the new location

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@
 var config = require('./config')
 var dbServer = require('fxa-auth-db-server')
 var error = dbServer.errors
-var log = require('./log')(config.logLevel, 'db-api')
-var DB = require('./db')(log, error)
+var logger = require('./logging')('bin.server')
+var DB = require('./db')(logger, error)
 
 module.exports = function () {
   return DB.connect(config)


### PR DESCRIPTION
@chilts r? 

So, fxa-auth-server had not had the git sha bumped to pick up the recent changes in fxa-auth-db-mem, 
and when I did so, it turned up this missing change. With that fixed all tests pass in both modules. 

I have another PR to fix the version in fxa-auth-server, but am holding that back until this one gets merge, since tests of that PR would be failing until then.