### PR TITLE
fix(package): Remove uuid completely since no longer needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "grunt-contrib-jshint": "0.10.0",
     "grunt-copyright": "0.1.0",
     "load-grunt-tasks": "0.6.0",
-    "tap": "0.4.13",
-    "uuid": "1.4.1"
+    "tap": "0.4.13"
   },
   "keywords": [ "fxa", "firefox", "firefox-accounts", "backend", "storage", "memory" ]
 }


### PR DESCRIPTION
Since node-uuid / uuid has been removed from fxa-auth-db-server, we no
longer have to install it here. Having it here used to upset shrinkwrap
if conflicting versions were being used and/or installed (e.g. uuid v1 to
uuid v2 - the APIs were incompatible. See the issue for more details.

Fixes #23.