### PR TITLE
chore(copyright): Update to grunt-copyright v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ass": "git://github.com/jrgm/ass.git#5be99ee",
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "0.10.0",
-    "grunt-copyright": "0.1.0",
+    "grunt-copyright": "0.2.0",
     "load-grunt-tasks": "0.6.0",
     "tap": "0.4.13",
     "uuid": "1.4.1"


### PR DESCRIPTION
When doing an `npm install` using node v0.12, it complains since grunt-copyright
v0.1 has a `"node": "0.10.x"` in it's `engines` section. v0.2 has been updated
to be `"node": ">= 0.10.0"` which is satisfied with either v0.10 or v0.12.