### PR TITLE
feat(tests): pass the server.on function to backend tests

### DIFF
--- a/test/backend/remote.js
+++ b/test/backend/remote.js
@@ -26,14 +26,14 @@ DB.connect(config)
     server = dbServer.createServer(db)
     var d = P.defer()
     server.listen(config.port, config.hostname, function() {
-      d.resolve()
+      d.resolve(server)
     })
     server.on('failure', function (d) { console.error(d.err.code, d.url)})
     server.on('success', function (d) { console.log(d.method, d.url)})
     return d.promise
   })
-  .then(function() {
-    return backendTests.remote(config)
+  .then(function(server) {
+    return backendTests.remote(config, server)
   })
   .then(function() {
     server.close()


### PR DESCRIPTION
@chilts @rfk

This is a proposal to enable functional tests of server emitted events. It just involves passing the bound `server.on` function to the backend tests, so that they can listen for any events of interest.

For usage, see the incoming fxa-auth-db-server PR (I'll refer to this PR from that one).

Not sure how you guys feel about it or where it lies on the hackishness spectrum, but it was the simplest thing I could think of to do what I wanted. Thoughts?