### PR TITLE
fix(db): check that a uid was passed in args

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -20,6 +20,9 @@ module.exports = function (log, error) {
   function Memory(db) {}
 
   function getAccountByUid (uid) {
+    if (!uid) {
+      return P.reject(error.notFound())
+    }
     uid = uid.toString('hex')
     if ( accounts[uid] ) {
       return P.resolve(accounts[uid])


### PR DESCRIPTION
This fixes one of the issues from https://github.com/mozilla/fxa-auth-server/issues/993, where mem-backed tests are failing if auth-server pulls in latest fxa-auth-db-{server,mem}.

This was changed in https://github.com/mozilla/fxa-auth-db-mem/commit/603d4c29e7477977b335fa13c59cf935a02caae2. Formerly there was checking that the user could be found in emailRecord. Looks like tests are missing some cases.