### PR TITLE
feat(db): store user agent and last-access time in sessionTokens

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -70,6 +70,8 @@ module.exports = function (log, error) {
       data: sessionToken.data,
       uid: sessionToken.uid,
       createdAt: sessionToken.createdAt,
+      userAgent: sessionToken.userAgent,
+      lastAccessTime: sessionToken.lastAccessTime
     }
 
     var account = accounts[sessionToken.uid.toString('hex')]
@@ -294,6 +296,8 @@ module.exports = function (log, error) {
     item.tokenData = sessionTokens[id].data
     item.uid = sessionTokens[id].uid
     item.createdAt = sessionTokens[id].createdAt
+    item.userAgent = sessionTokens[id].userAgent
+    item.lastAccessTime = sessionTokens[id].lastAccessTime
 
     var accountId = sessionTokens[id].uid.toString('hex')
     var account = accounts[accountId]
@@ -511,10 +515,22 @@ module.exports = function (log, error) {
     return P.resolve(unlockCode)
   }
 
+  // UPDATE
+
   Memory.prototype.updatePasswordForgotToken = function (id, data) {
     var token = passwordForgotTokens[id.toString('hex')]
     if (!token) { return P.reject(error.notFound()) }
     token.tries = data.tries
+    return P.resolve({})
+  }
+
+  Memory.prototype.updateSessionToken = function (id, data) {
+    var token = sessionTokens[id.toString('hex')]
+    if (!token) {
+      return P.reject(error.notFound())
+    }
+    token.userAgent = data.userAgent
+    token.lastAccessTime = data.lastAccessTime
     return P.resolve({})
   }
 


### PR DESCRIPTION
Partially addresses https://github.com/mozilla/fxa-auth-server/issues/983.

Depends on:

* https://github.com/mozilla/fxa-auth-db-mysql/pull/65
* https://github.com/mozilla/fxa-auth-server/pull/997

Adds `userAgent` and `lastAccessTime` to `sessionTokens`.